### PR TITLE
[@types/async] - Fix mapValues return type and extend the iteratee type to accomodate more cases

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -280,7 +280,10 @@ export function mapValuesLimit<T, R, E = Error>(
 ): Promise<R>;
 
 export function mapValues<T, R, E = Error>(obj: Dictionary<T>, iteratee: (value: T, key: string, callback: AsyncResultCallback<R, E>) => void, callback: AsyncResultObjectCallback<R, E>): void;
-export function mapValues<T, R, E = Error>(obj: Dictionary<T>, iteratee: (value: T, key: string, callback: AsyncResultCallback<R, E>) => void): Promise<R>;
+export function mapValues<T, R, E = Error, C = unknown>(
+    obj: Dictionary<T>,
+    iteratee: (value: T, key: string, callback: C extends undefined ? never : AsyncResultCallback<R, E>) => C extends undefined ? Promise<R> : void
+): Promise<Dictionary<R>>;
 export const mapValuesSeries: typeof mapValues;
 export function filter<T, E = Error>(arr: IterableCollection<T>, iterator: AsyncBooleanIterator<T, E>, callback: AsyncResultArrayCallback<T, E>): void;
 export function filter<T, E = Error>(arr: IterableCollection<T>, iterator: AsyncBooleanIterator<T, E>): Promise<T[]>;

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -632,6 +632,7 @@ async.mapValues<number, string>(
     (err: Error, results: Dictionary<string>) => { console.log("async.mapValues: done with results", results); }
 );
 
+// $ExpectType Promise<Dictionary<string>>
 async.mapValues(
     { a: 1, b: 2, c: 3 },
     async (val, key) => {
@@ -645,8 +646,9 @@ async.mapValues(
         });
        return newVal + ' with async/await';
     },
-).then((results) => { console.log("async.mapValues promise: done with results", results); });
+);
 
+// $ExpectType Promise<Dictionary<string>>
 async.mapValues<number, string>(
     { a: 1, b: 2, c: 3 },
     (val, key, next) => {
@@ -657,7 +659,7 @@ async.mapValues<number, string>(
             },
             500);
     },
-).then((results) => { console.log("async.mapValues promise: done with results", results); });
+);
 
 async.mapValuesSeries<number, string>(
     { a: 1, b: 2, c: 3 },

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -635,6 +635,7 @@ async.mapValues<number, string>(
 // $ExpectType Promise<Dictionary<string>>
 async.mapValues(
     { a: 1, b: 2, c: 3 },
+    // $ExpectType (val: number, key: string) => Promise<string>
     async (val, key) => {
         const newVal = await new Promise<string>((resolve) => {
             setTimeout(
@@ -651,6 +652,7 @@ async.mapValues(
 // $ExpectType Promise<Dictionary<string>>
 async.mapValues<number, string>(
     { a: 1, b: 2, c: 3 },
+    // $ExpectType (val: number, key: string, next: AsyncResultCallback<string, Error>) => void
     (val, key, next) => {
         setTimeout(
             () => {

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -632,6 +632,33 @@ async.mapValues<number, string>(
     (err: Error, results: Dictionary<string>) => { console.log("async.mapValues: done with results", results); }
 );
 
+async.mapValues(
+    { a: 1, b: 2, c: 3 },
+    async (val, key) => {
+        const newVal = await new Promise<string>((resolve) => {
+            setTimeout(
+                () => {
+                    console.log(`async.mapValues: ${key} = ${val}`);
+                    resolve(val.toString());
+                },
+                500);
+        });
+       return newVal + ' with async/await';
+    },
+).then((results) => { console.log("async.mapValues promise: done with results", results); });
+
+async.mapValues<number, string>(
+    { a: 1, b: 2, c: 3 },
+    (val, key, next) => {
+        setTimeout(
+            () => {
+                console.log(`async.mapValues: ${key} = ${val}`);
+                next(null, val.toString());
+            },
+            500);
+    },
+).then((results) => { console.log("async.mapValues promise: done with results", results); });
+
 async.mapValuesSeries<number, string>(
     { a: 1, b: 2, c: 3 },
     (val: number, key: string, next: AsyncResultCallback<string>) => {

--- a/types/async/tslint.json
+++ b/types/async/tslint.json
@@ -1,6 +1,8 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
-        "ban-types": false
+        "ban-types": false,
+        "no-outside-dependencies": false,
+        "void-return": false
     }
 }

--- a/types/async/tslint.json
+++ b/types/async/tslint.json
@@ -2,7 +2,6 @@
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
         "ban-types": false,
-        "no-outside-dependencies": false,
         "void-return": false
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://caolan.github.io/async/v3/docs.html#mapValues](https://caolan.github.io/async/v3/docs.html#mapValues)


### Description

> If no callback is passed, `mapValues` returns a promise.

 Even though it appears to be correctly typed, the function signature type is incorrect because the returned promise is a `Dictionary<R>` instead of `R`. The rationale is that when we transform object values, we produce an object with the new values, not the type of those values.

The `iteratee` function was changed to support `async/await` code. With this change, we can plug asynchronous functions that return a promise, removing the need to use the callback argument of the `iteratee`.

The new tests reproduce these changes.